### PR TITLE
Refresh site content and modernize layout (portrait, Cozart link, curated projects)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,59 @@
 <!doctype HTML>
 <html lang="it">
-	<head>
-		<link rel="stylesheet" href="./stylesheet.css">
-		<title>Home</title>
-	</head>
-	<body>
+  <head>
+    <link rel="stylesheet" href="./stylesheet.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Alessandro Borsato</title>
+  </head>
+  <body>
     <header>
       <a href="./index.html">
         <h1 class="nameLink">Borsato Alessandro</h1>
       </a>
-  
+
       <div class="github">
         <a href="https://github.com/Slthy">
           <div class="githubLink">
-            <img 
-                class="homeGithubPic" 
-                title="Github Page"
-                alt="Borsato Alessandro's Github profile picture" 
-              >
-              <h1 class=gitSlash>&ThinSpace;/Slthy</h1>
+            <img
+              class="homeGithubPic"
+              title="Github Page"
+              alt="Borsato Alessandro's Github profile picture"
+            >
+            <h1 class="gitSlash">&ThinSpace;/Slthy</h1>
           </div>
         </a>
       </div>
-  
+
       <div class="menu">
         <a href="./projects.html">
           <h2 class="menuText">projects</h2>
         </a>
         <a href="./lastSeen.html">
-          <h2 class="menuText">interesting things</h2>
+          <h2 class="menuText">now</h2>
         </a>
-        <!--
-        <a class="menuText" href="./aboutme.html">
-          <h2>about me</h2>
-        </a>
-        -->
       </div>
     </header>
-	</body>
+
+    <main class="heroLayout">
+      <section class="heroCard">
+        <p class="tag">Data • Software • Research</p>
+        <h2 class="heroTitle">I build tools that turn messy data into useful systems.</h2>
+        <p class="heroText">
+          I am Alessandro Borsato, a developer focused on data-heavy products, scraping pipelines,
+          and research-driven software. Most of my work sits at the intersection of reliability,
+          performance, and practical UX.
+        </p>
+        <p class="heroText">
+          I enjoy creating small systems that scale well: from sports-data workflows to collaborative
+          products, with clean interfaces and straightforward engineering choices.
+        </p>
+      </section>
+
+      <aside class="portraitCard">
+        <img class="portrait" src="https://github.com/Slthy.png" alt="Portrait of Alessandro Borsato">
+        <p class="portraitCaption">A face to the code. Replace with your favorite portrait anytime.</p>
+      </aside>
+    </main>
+  </body>
 </html>

--- a/lastSeen.html
+++ b/lastSeen.html
@@ -1,95 +1,62 @@
 <!doctype HTML>
 <html lang="it">
-
-<head>
+  <head>
     <link rel="stylesheet" href="./stylesheet.css">
-    <title>Interesting Things</title>
-</head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Now</title>
+  </head>
 
-<body>
+  <body>
     <header>
-        <a href="./index.html">
-            <h1 class="nameLink">Borsato Alessandro</h1>
-        </a>
-
-        <div class="github">
-            <a href="https://github.com/Slthy">
-                <div class="githubLink">
-                    <img class="homeGithubPic" title="Github Page" alt="Borsato Alessandro's Github profile picture">
-                    <h1 class=gitSlash>&ThinSpace;/Slthy</h1>
-                </div>
-            </a>
-        </div>
-
-        <div class="menu">
-            <a href="./projects.html">
-                <h2 class="menuText">projects</h2>
-            </a>
-            <a href="./lastSeen.html">
-                <h2 class="menuText" style="color: rgb(134, 133, 133)">interesting things</h2>
-            </a>
-            <!--
-      <a class="menuText" href="./aboutme.html">
-        <h2>about me</h2>
+      <a href="./index.html">
+        <h1 class="nameLink">Borsato Alessandro</h1>
       </a>
-      -->
-        </div>
+
+      <div class="github">
+        <a href="https://github.com/Slthy">
+          <div class="githubLink">
+            <img class="homeGithubPic" title="Github Page" alt="Borsato Alessandro's Github profile picture">
+            <h1 class="gitSlash">&ThinSpace;/Slthy</h1>
+          </div>
+        </a>
+      </div>
+
+      <div class="menu">
+        <a href="./projects.html">
+          <h2 class="menuText">projects</h2>
+        </a>
+        <a href="./lastSeen.html">
+          <h2 class="menuText menuActive">now</h2>
+        </a>
+      </div>
     </header>
 
-    <div class="entries">
-        <div class="lastSeenContainer">
-            <h3 class="link">
-                <a class="projectName" href="https://nyansatan.github.io/lightning/">
-                    Apple Lightning technology and its dependencies (Tristar, Hydra, HiFive, SDQ, IDBUS).
-                </a>
-            </h3>
-        </div>
-        <div class="lastSeenContainer">
-            <iframe width="560" height="315" class="video" src="https://www.youtube-nocookie.com/embed/kvREvOvSWt4"
-                title="YouTube video player" frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
-        </div>
-        <div class="lastSeenContainer">
-            <h3 class="link">
-                <a class="projectName" href="https://linear.app/blog/settings-are-not-a-design-failure">
-                    Settings are not a design failure.
-                </a>
-            </h3>
-        </div>
-        <div class="lastSeenContainer">
-            <iframe width="560" height="315" class="video" src="https://www.youtube-nocookie.com/embed/bdoINmJFw3M"
-                title="YouTube video player" frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
-        </div>
-        <div class="lastSeenContainer">
-            <iframe width="560" height="315" class="video" src="https://www.youtube-nocookie.com/embed/XufMmi7DAek"
-                title="YouTube video player" frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
-        </div>
-        <div class="lastSeenContainer">
-            <h3 class="link">
-                <a class="projectName" href="https://linear.app/blog/settings-are-not-a-design-failure">
-                    Failing to Reach DDR4 Bandwidth of AMD Zen2 in Parallel Reductions.
-                </a>
-            </h3>
-        </div>
-        <div class="lastSeenContainer">
-            <iframe width="560" height="315" class="video" src="https://www.youtube-nocookie.com/embed/WJgLKO-qac0"
-                title="YouTube video player" frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
-        </div>
-        <div class="lastSeenContainer">
-            <iframe width="560" height="315" class="video" src="https://www.youtube-nocookie.com/embed/cJkx-OLgLzo"
-                title="YouTube video player" frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
-        </div>
-    </div>
+    <main class="entries">
+      <div class="lastSeenContainer">
+        <h3>What I am focused on now</h3>
+        <ul>
+          <li>Advancing the Cozart research project and documenting progress.</li>
+          <li>Building robust data workflows for swimming-related software products.</li>
+          <li>Improving quality through simpler architecture and clearer interfaces.</li>
+        </ul>
+      </div>
 
-</body>
+      <div class="lastSeenContainer">
+        <h3>How I work</h3>
+        <p>
+          I prefer small, maintainable systems over over-engineering. I care about clear naming,
+          measurable outcomes, and products that remain understandable six months later.
+        </p>
+      </div>
 
+      <div class="lastSeenContainer">
+        <h3>Elsewhere</h3>
+        <p>
+          You can follow code and ongoing experiments on
+          <a class="projectName" href="https://github.com/Slthy">GitHub</a>.
+        </p>
+      </div>
+    </main>
+  </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -1,116 +1,73 @@
 <!doctype HTML>
 <html lang="it">
-
-<head>
+  <head>
     <link rel="stylesheet" href="./stylesheet.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Projects</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <header>
-        <a href="./index.html">
-            <h1 class="nameLink">Borsato Alessandro</h1>
-        </a>
+      <a href="./index.html">
+        <h1 class="nameLink">Borsato Alessandro</h1>
+      </a>
 
-        <div class="github">
-            <a href="https://github.com/Slthy">
-                <div class="githubLink">
-                    <img class="homeGithubPic" title="Github Page" alt="Borsato Alessandro's Github profile picture">
-                    <h1 class=gitSlash>&ThinSpace;/Slthy</h1>
-                </div>
-            </a>
-        </div>
-
-        <div class="menu">
-            <a href="./projects.html">
-                <h2 class="menuText" style="color: rgb(134, 133, 133)">projects</h2>
-            </a>
-            <a href="./lastSeen.html">
-                <h2 class="menuText">interesting things</h2>
-            </a>
-            <!--
-        <a class="menuText" href="./aboutme.html">
-            <h2>about me</h2>
+      <div class="github">
+        <a href="https://github.com/Slthy">
+          <div class="githubLink">
+            <img class="homeGithubPic" title="Github Page" alt="Borsato Alessandro's Github profile picture">
+            <h1 class="gitSlash">&ThinSpace;/Slthy</h1>
+          </div>
         </a>
-        -->
-        </div>
+      </div>
+
+      <div class="menu">
+        <a href="./projects.html">
+          <h2 class="menuText menuActive">projects</h2>
+        </a>
+        <a href="./lastSeen.html">
+          <h2 class="menuText">now</h2>
+        </a>
+      </div>
     </header>
 
-    <div class="entries">
-        <!--Microplus-Lenex-->
-        <div class="projectContainer">
-            <h3>
-                <a class="projectName" href="https://github.com/Slthy/Microplus-Lenex"> Microplus-Lenex: Lenex encoder for swimming competitions</a>
-            </h3>
-            <p class="Microplus-Lenex">
-                <strong>Microplus-Lenex</strong> is a Web scraper and Lenex encoder for swimming events hosted by Microplus s.r.l.<br>
-                The scripts convert results from Microplus's website into an XML text file, following the Lenex 3.0 guidelines.
-            </p>
-        </div>
+    <main class="entries">
+      <div class="projectContainer">
+        <h3>
+          <a class="projectName" href="https://sibin.github.io/projects/cozart">
+            Cozart (Research): current research project
+          </a>
+        </h3>
+        <p>
+          My current research focus is <strong>Cozart</strong>, where I contribute to experimentation,
+          implementation, and iteration cycles for the project outcomes.
+        </p>
+      </div>
 
+      <div class="projectContainer">
+        <h3>
+          <a class="projectName" href="https://fantanuoto.it">
+            Fantanuoto.it: swimming fantasy game
+          </a>
+        </h3>
+        <p>
+          Closed-source product for international swimming events. I work on ingestion pipelines,
+          data normalization, and backend workflows that support league and game logic.
+        </p>
+      </div>
 
-        <!--Fantanuoto-->
-        <div class="projectContainer">
-            <h3>
-                <a class="projectName" href="https://fantanuoto.it"> Fantanuoto.it: the most played swimming fantasy-game in Italy.</a>
-            </h3>
-            <p class="Fantanuoto">
-                <strong>Fantanuoto.it</strong> is a closed-source fantasy-game for international swimming events where users can sign up to the website and create/join leagues to play with friends.<br>
-                The project is in development, but small tests have been performed during the last international swimming competitions.<br>
-                My contributions involved the scraping and formatting of data from various sourced (without APIs) and other back-end interfaces.
-            </p>
-        </div>
-
-        <!--fnTrackingPros-->
-        <div class="projectContainer">
-            <h3>
-                <a class="projectName" href="https://github.com/Slthy/fnTrackingPros"> fnTrackingPros: User-friendly CLI tool to retrive, store and elaborate data from fortnite competitions</a>
-            </h3>
-            <p class="fnTrackingPros">
-                <strong>fnTrackingPros</strong> is a tool that tracks changes in the seasonal Fortnite's Power Ranking Leaderboard.<br>
-                The scripts gives the users useful infos regarding the season trends.
-            </p>
-        </div>
-
-        <!--touchy-->
-        <div class="projectContainer">
-            <h3>
-                <a class="projectName" href="https://github.com/Slthy/touchy"> touchy: a SvelteKit-based social
-                    network</a>
-            </h3>
-            <p class="touchyInfos">
-                <strong>Touchy</strong> is a SvelteKit-based social network with a sleek black and white interface. The
-                goal for this new-born platform is to reward user's creativity through the engagement algorithm.<br>
-                With the same importance, we also beleve that our user's privacy should always be protected: no
-                adv-cookie is used in our systems.
-            </p>
-        </div>
-
-        <!--Unpwn-->
-        <div class="projectContainer">
-            <h3>
-                <a class="projectName" href="https://github.com/Slthy/Unpwn"> Unpwn: as simple as secure</a>
-            </h3>
-            <p class="unpwnInfos">
-                <strong>Unpwn</strong> is a lightweight iOS Password manager that helps to keep your accounts safe from
-                being pwned. With a simple UI, Unpwn helps people to secure their accounts, creating passwords based on
-                user&#39;s preferences.<br>Every user can:
-            </p>
-            <ol>
-                <li>Decide to use lowercase characters in their passwords.</li>
-                <li>Decide to use uppercase characters in their passwords.</li>
-                <li>Decide to use numbers in their passwords.</li>
-                <li>Decide to use special characters in their passwords.</li>
-                <li>The password's length, from 1 to 64 characters.</li>
-            </ol>
-            <p class="unpwnInfos">
-                In version 2.0, Unpwn can check if your own password has been part of data breaches through <em>Have i
-                    been pwned?</em>&#39;s database.
-            </p>
-        </div>
-    </div>
-
-
-</body>
-
+      <div class="projectContainer">
+        <h3>
+          <a class="projectName" href="https://github.com/Slthy/Microplus-Lenex">
+            Microplus-Lenex: Lenex encoder for swimming competitions
+          </a>
+        </h3>
+        <p>
+          Web scraping and XML conversion toolkit that transforms event data into Lenex 3.0-compliant files,
+          designed for practical usage in swimming competition workflows.
+        </p>
+      </div>
+    </main>
+  </body>
 </html>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,12 +1,26 @@
 * {
+  box-sizing: border-box;
   font-family: Arial, Helvetica, sans-serif;
-  color: black;
-  font-size: 3vh;
+  color: #121212;
 }
 
-body{
+body {
+  margin: 0;
   padding: 2.5em;
-  padding-bottom: 100px;
+  padding-bottom: 80px;
+  background: #fafafa;
+  line-height: 1.45;
+}
+
+header {
+  border-bottom: 1px solid #d4d4d4;
+  padding-bottom: 1em;
+  margin-bottom: 2em;
+}
+
+.nameLink {
+  font-size: clamp(2.1rem, 4vw, 3.2rem);
+  margin: 0;
 }
 
 .githubLink {
@@ -15,65 +29,117 @@ body{
   flex-wrap: wrap;
   height: 75px;
   justify-content: center;
+  margin-top: 0.4em;
 }
 
-.gitSlash{
-  font-size: 50px;
+.homeGithubPic {
+  content: url("./assets/github-white.png");
+  width: 75px;
+  height: 75px;
 }
 
-.menu{
+.gitSlash {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  margin: 0;
+}
+
+.menu {
   display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content:first baseline; 
+  gap: 1.4em;
+  margin-top: 0.6em;
 }
 
-.menuText{
-  margin-right: 1em;
+.menuText {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 500;
 }
 
-.entries{
-  border-radius: 50%;
-  padding-top: 2.5em;
+.menuActive {
+  color: #8a8a8a;
+}
+
+.entries {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
+  max-width: 920px;
+}
+
+.projectContainer,
+.lastSeenContainer,
+.heroCard,
+.portraitCard {
+  padding: 18px 22px;
+  border: 1px solid #d0d0d0;
+  border-radius: 14px;
+  background: #fff;
 }
 
 a {
   text-decoration: none;
 }
 
-.projectContainer, .lastSeenContainer{
-  padding-inline: 20px;
-  border-style: solid;
-  border-radius: 15px;
-  border-color: darkgray;
+.projectName {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
-.lastSeenContainer{
-  width:560px
-}
-.video{
-  margin-top: 15px;
-  margin-bottom: 10px;
-  margin-right: 10px;
+.heroLayout {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 18px;
+  max-width: 1000px;
 }
 
-.nameLink{
-  font-size: 3em;
+.tag {
+  margin: 0 0 8px 0;
+  color: #686868;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.homeGithubPic{
-  content:url("./assets/github-white.png");
-  width: 75px;
-  height: 75px;
+.heroTitle {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.6vw, 2.2rem);
+}
+
+.heroText {
+  margin-bottom: 0;
+  font-size: 1.05rem;
+}
+
+.portrait {
+  width: 100%;
+  aspect-ratio: 1/1;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid #dadada;
+}
+
+.portraitCaption {
+  margin-bottom: 0;
+  font-size: 0.95rem;
+  color: #555;
 }
 
 .homeGithubPic:hover ~ .gitSlash,
-  .projectName:hover, 
-  .menuText:hover,
-  .nameLink:hover,
-  .gitSlash:hover{
-  color: rgb(187, 187, 187);
+.projectName:hover,
+.menuText:hover,
+.nameLink:hover,
+.gitSlash:hover {
+  color: #a7a7a7;
+}
+
+@media (max-width: 860px) {
+  body {
+    padding: 1.2em;
+  }
+
+  .heroLayout {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
### Motivation
- Bring the site copy and structure up-to-date while preserving the original minimal monochrome style.  
- Emphasize current work and research instead of an undifferentiated link dump.  
- Provide a clear place for a portrait and a stronger personal intro so visitors quickly understand who you are.  
- Remove older, low-signal projects and highlight the active/relevant ones (including the requested research link).

### Description
- Updated landing page `index.html` with a focused hero: stronger intro text, tags (`Data • Software • Research`), and a portrait card that loads `https://github.com/Slthy.png`.  
- Replaced the old "interesting things" pages/label with a concise `now` section in `lastSeen.html` describing current focus and workflow.  
- Curated `projects.html` to remove older entries and surface the current research project `Cozart` with the requested link `https://sibin.github.io/projects/cozart`, plus kept a few active projects.  
- Modernized shared styling in `stylesheet.css`: updated spacing, responsive typography, card layout, menu state (`.menuActive`), and a two-column hero grid that collapses on small screens.

### Testing
- Ran `git diff --check`, which reported no whitespace or diff-check issues (success).  
- Attempted HTML validation with `xmllint --html --noout`, but `xmllint` is not installed in this environment (not run).  
- Tried to generate a screenshot with Playwright (`npx playwright screenshot ...`) but browser binaries were not available and `npx playwright install chromium` failed due to network/download restrictions (Playwright download returned `403 Domain forbidden`).  
- Files changed and committed on the current branch: `index.html`, `projects.html`, `lastSeen.html`, `stylesheet.css` (commit message: "Refresh site content and modernize layout").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05090f2e08324a2e0333ee53e2ab5)