### PR TITLE
Update homepage hero copy and remove portrait/card styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,23 +37,28 @@
 
     <main class="heroLayout">
       <section class="heroCard">
-        <p class="tag">Data • Software • Research</p>
-        <h2 class="heroTitle">I build tools that turn messy data into useful systems.</h2>
+        <p class="tag">About</p>
+        <h2 class="heroTitle">I build reliable software for data-heavy products.</h2>
         <p class="heroText">
-          I am Alessandro Borsato, a developer focused on data-heavy products, scraping pipelines,
-          and research-driven software. Most of my work sits at the intersection of reliability,
-          performance, and practical UX.
+          I'm Alessandro Borsato. I work on pipelines, backend workflows, and research projects
+          where quality and clarity matter more than hype.
         </p>
         <p class="heroText">
-          I enjoy creating small systems that scale well: from sports-data workflows to collaborative
-          products, with clean interfaces and straightforward engineering choices.
+          This site is intentionally simple: fast to load, readable, and focused on content.
         </p>
       </section>
 
-      <aside class="portraitCard">
-        <img class="portrait" src="https://github.com/Slthy.png" alt="Portrait of Alessandro Borsato">
-        <p class="portraitCaption">A face to the code. Replace with your favorite portrait anytime.</p>
-      </aside>
+      <section class="heroCard">
+        <p class="tag">A bit more about me</p>
+        <p class="heroText">
+          Outside coding, I care about sport, disciplined routines, and long-term projects.
+          I prefer steady progress over noise and like building things that stay useful over time.
+        </p>
+        <p class="heroText">
+          If you want details, you can check my <a class="projectName" href="./projects.html">projects</a>
+          and what I am focused on <a class="projectName" href="./lastSeen.html">now</a>.
+        </p>
+      </section>
     </main>
   </body>
 </html>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -69,8 +69,7 @@ header {
 
 .projectContainer,
 .lastSeenContainer,
-.heroCard,
-.portraitCard {
+.heroCard {
   padding: 18px 22px;
   border: 1px solid #d0d0d0;
   border-radius: 14px;
@@ -112,19 +111,7 @@ a {
   font-size: 1.05rem;
 }
 
-.portrait {
-  width: 100%;
-  aspect-ratio: 1/1;
-  object-fit: cover;
-  border-radius: 10px;
-  border: 1px solid #dadada;
-}
 
-.portraitCaption {
-  margin-bottom: 0;
-  font-size: 0.95rem;
-  color: #555;
-}
 
 .homeGithubPic:hover ~ .gitSlash,
 .projectName:hover,


### PR DESCRIPTION
### Motivation
- Simplify and focus the homepage messaging to emphasize reliability and clarity over verbose marketing.
- Remove the portrait element to keep the page visually minimal and privacy-friendly.

### Description
- Rewrote the hero section copy in `index.html` (updated `.tag`, `.heroTitle`, and `.heroText` paragraphs) to shorter, clearer messaging.
- Replaced the portrait `aside` with a second `.heroCard` containing a short personal blurb and links to `./projects.html` and `./lastSeen.html`.
- Removed the portrait markup and deleted related CSS selectors and rules (`.portrait`, `.portraitCaption`, and `.portraitCard` usage) from `stylesheet.css` and consolidated the `.heroCard` rule.
- Adjusted layout content while preserving the existing responsive grid in `.heroLayout`.

### Testing
- No automated tests were added or run for this content and style change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f053789d848324be55dc0b14a1951f)