### PR TITLE
Refactor header: place GitHub logo beside name and add hover interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,20 +8,17 @@
   </head>
   <body>
     <header>
-      <a href="./index.html">
-        <h1 class="nameLink">Borsato Alessandro</h1>
-      </a>
-
-      <div class="github">
-        <a href="https://github.com/Slthy">
-          <div class="githubLink">
-            <img
-              class="homeGithubPic"
-              title="Github Page"
-              alt="Borsato Alessandro's Github profile picture"
-            >
-            <h1 class="gitSlash">&ThinSpace;/Slthy</h1>
-          </div>
+      <div class="identity">
+        <a href="./index.html">
+          <h1 class="nameLink">Borsato Alessandro</h1>
+        </a>
+        <a class="githubIconLink" href="https://github.com/Slthy" aria-label="Github profile">
+          <img
+            class="homeGithubPic"
+            src="./assets/github-white.png"
+            title="Github Page"
+            alt="Borsato Alessandro's Github profile picture"
+          >
         </a>
       </div>
 

--- a/lastSeen.html
+++ b/lastSeen.html
@@ -8,15 +8,12 @@
 </head>
 <body>
     <header>
-        <a href="./index.html">
-            <h1 class="nameLink">Borsato Alessandro</h1>
-        </a>
-        <div class="github">
-            <a href="https://github.com/Slthy">
-                <div class="githubLink">
-                    <img class="homeGithubPic" title="Github Page" alt="Borsato Alessandro's Github">
-                    <h1 class="gitSlash">&ThinSpace;/Slthy</h1>
-                </div>
+        <div class="identity">
+            <a href="./index.html">
+                <h1 class="nameLink">Borsato Alessandro</h1>
+            </a>
+            <a class="githubIconLink" href="https://github.com/Slthy" aria-label="Github profile">
+                <img class="homeGithubPic" src="./assets/github-white.png" title="Github Page" alt="Borsato Alessandro's Github">
             </a>
         </div>
         <div class="menu">

--- a/projects.html
+++ b/projects.html
@@ -9,16 +9,17 @@
 
   <body>
     <header>
-      <a href="./index.html">
-        <h1 class="nameLink">Borsato Alessandro</h1>
-      </a>
-
-      <div class="github">
-        <a href="https://github.com/Slthy">
-          <div class="githubLink">
-            <img class="homeGithubPic" title="Github Page" alt="Borsato Alessandro's Github profile picture">
-            <h1 class="gitSlash">&ThinSpace;/Slthy</h1>
-          </div>
+      <div class="identity">
+        <a href="./index.html">
+          <h1 class="nameLink">Borsato Alessandro</h1>
+        </a>
+        <a class="githubIconLink" href="https://github.com/Slthy" aria-label="Github profile">
+          <img
+            class="homeGithubPic"
+            src="./assets/github-white.png"
+            title="Github Page"
+            alt="Borsato Alessandro's Github profile picture"
+          >
         </a>
       </div>
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -21,26 +21,30 @@ header {
 .nameLink {
   font-size: clamp(2.1rem, 4vw, 3.2rem);
   margin: 0;
+  transition: color 0.2s ease;
 }
 
-.githubLink {
+.identity {
   display: inline-flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  height: 75px;
+  align-items: center;
+  gap: 0.65em;
+}
+
+.githubIconLink {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
-  margin-top: 0.4em;
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background: #121212;
+  transition: background-color 0.2s ease;
 }
 
 .homeGithubPic {
-  content: url("./assets/github-white.png");
-  width: 75px;
-  height: 75px;
-}
-
-.gitSlash {
-  font-size: clamp(1.6rem, 3vw, 2.4rem);
-  margin: 0;
+  width: 28px;
+  height: 28px;
+  display: block;
 }
 
 .menu {
@@ -111,13 +115,16 @@ a {
   font-size: 1.05rem;
 }
 
+.identity:hover .nameLink {
+  color: #a7a7a7;
+}
 
+.identity:hover .githubIconLink {
+  background-color: #6d6d6d;
+}
 
-.homeGithubPic:hover ~ .gitSlash,
 .projectName:hover,
-.menuText:hover,
-.nameLink:hover,
-.gitSlash:hover {
+.menuText:hover {
   color: #a7a7a7;
 }
 


### PR DESCRIPTION
### Motivation
- Group the site identity so the GitHub logo appears only next to the name and not as a separate text element.
- Make the header interactive so hovering the name or the logo updates the other element's visual state.
- Use the provided alternate logo asset for the header icon (`assets/github-white.png`).

### Description
- Replaced the previous name + `/Slthy` block with a single `.identity` wrapper in `index.html`, `projects.html`, and `lastSeen.html` and added an inline GitHub icon link (`.githubIconLink`) containing the image `./assets/github-white.png`.
- Removed the `/Slthy` heading element and simplified the GitHub markup so only the logo appears next to the name.
- Added CSS rules in `stylesheet.css` for `.identity`, `.githubIconLink`, and `.homeGithubPic`, adjusted sizes and spacing, and added transitions for hover feedback.
- Implemented shared hover behavior so `.identity:hover .nameLink` changes the name color and `.identity:hover .githubIconLink` changes the logo container background while keeping existing `projectName` and `menuText` hover styles.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted a visual screenshot via Playwright with `npx playwright screenshot` but the environment blocked browser downloads (Playwright CDN returned HTTP 403), so the screenshot step failed due to missing browser binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0565caf1083249b49f7577e8c1cae)