### PR TITLE
Fix GitHub logo visibility in site header

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -45,6 +45,7 @@ header {
   width: 28px;
   height: 28px;
   display: block;
+  filter: brightness(0) invert(1);
 }
 
 .menu {


### PR DESCRIPTION
### Motivation
- The GitHub icon in the header was rendering as an all-black image and blending into the dark rounded button background, making it hard to see.

### Description
- Add `filter: brightness(0) invert(1);` to the `.homeGithubPic` rule in `stylesheet.css` so the existing PNG asset is rendered as a white icon and contrasts correctly against the dark button.

### Testing
- Ran `git diff -- stylesheet.css` to review the CSS change and it showed the new `filter` line (success).
- Ran `git status --short` to confirm the working tree state (success).
- Committed the change with `git commit -m "Fix GitHub logo visibility in header"` and verified the commit hash via `git rev-parse --short HEAD` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0582b23448324b83421e1bc54a41c)